### PR TITLE
Fix props.conf header formatting

### DIFF
--- a/splunk-configs/props.conf
+++ b/splunk-configs/props.conf
@@ -1,4 +1,4 @@
-apache_custom_fields]
+[apache_custom_fields]
 REGEX=] \w+ (\S+) "(.*?)" (OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT) (HTTP.\S+) (\S+) (\S+) (\d{3}) (\d+) (\d+)
 FORMAT=clientip::$1 useragent::$2 method::$3 protocol::$4 url::$5 uri_query::$6 status::$7 bytes::$8 timetaken::$9
 


### PR DESCRIPTION
## Summary
- correct the header for `apache_custom_fields` in `props.conf`

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_684024aceb088325a8684c1a1278c51b