### PR TITLE
Copy missing Splunk configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update && apt-get install -y wget curl && \
 
 # Configure Splunk
 COPY splunk-configs/inputs.conf /opt/splunkforwarder/etc/system/local/
+COPY splunk-configs/props.conf /opt/splunkforwarder/etc/system/local/
+COPY splunk-configs/transforms.conf /opt/splunkforwarder/etc/system/local/
 
 
 


### PR DESCRIPTION
## Summary
- add `props.conf` and `transforms.conf` to the Splunk forwarder image

## Testing
- `docker-compose config` *(fails: command not found)*

------
